### PR TITLE
Another OpenMP fix.

### DIFF
--- a/Eigen/src/Core/products/GeneralBlockPanelKernel.h
+++ b/Eigen/src/Core/products/GeneralBlockPanelKernel.h
@@ -90,21 +90,6 @@ struct CacheSizes {
   std::ptrdiff_t m_l3;
 };
 
-// In C++17 this could be an inline variable, see for example
-// https://stackoverflow.com/questions/38043442/how-do-inline-variables-work
-template <typename>
-struct CacheSizeGlobalHelper {
-  static CacheSizes s_cacheSizes;
-};
-#ifdef _OPENMP
-#pragma omp declare target
-#endif
-template <typename T>
-CacheSizes CacheSizeGlobalHelper<T>::s_cacheSizes;
-#ifdef _OPENMP
-#pragma omp end declare target
-#endif
-
 /** \internal */
 EIGEN_DEVICE_FUNC
 inline void manage_caching_sizes(Action action, std::ptrdiff_t* l1, std::ptrdiff_t* l2, std::ptrdiff_t* l3)
@@ -133,22 +118,22 @@ inline void manage_caching_sizes(Action action, std::ptrdiff_t* l1, std::ptrdiff
     eigen_internal_assert(false);
   }
   #else // EIGEN_CUDA_ARCH
+  static CacheSizes m_cacheSizes;
 
-  auto& cacheSizes = CacheSizeGlobalHelper<void>::s_cacheSizes;
   if(action==SetAction)
   {
     // set the cpu cache size and cache all block sizes from a global cache size in byte
     eigen_internal_assert(l1!=0 && l2!=0);
-    cacheSizes.m_l1 = *l1;
-    cacheSizes.m_l2 = *l2;
-    cacheSizes.m_l3 = *l3;
+    m_cacheSizes.m_l1 = *l1;
+    m_cacheSizes.m_l2 = *l2;
+    m_cacheSizes.m_l3 = *l3;
   }
   else if(action==GetAction)
   {
     eigen_internal_assert(l1!=0 && l2!=0);
-    *l1 = cacheSizes.m_l1;
-    *l2 = cacheSizes.m_l2;
-    *l3 = cacheSizes.m_l3;
+    *l1 = m_cacheSizes.m_l1;
+    *l2 = m_cacheSizes.m_l2;
+    *l3 = m_cacheSizes.m_l3;
   }
   else
   {

--- a/Eigen/src/Core/products/GeneralBlockPanelKernel.h
+++ b/Eigen/src/Core/products/GeneralBlockPanelKernel.h
@@ -94,10 +94,10 @@ struct CacheSizes {
 EIGEN_DEVICE_FUNC
 inline void manage_caching_sizes(Action action, std::ptrdiff_t* l1, std::ptrdiff_t* l2, std::ptrdiff_t* l3)
 {
-  #if defined(EIGEN_CUDA_ARCH) || defined(_OPENMP)
+  #if defined(EIGEN_CUDA_ARCH) || (defined(__NVCOMPILER) && defined(_OPENMP))
   if (action==GetAction)
   {
-    #if EIGEN_CUDA_ARCH >= 700 || defined(_OPENMP)
+    #if EIGEN_CUDA_ARCH >= 700 || (defined(__NVCOMPILER) && defined(_OPENMP))
     // Volta, Turing, or newer
     //   - the L1 cache is configurable at runtime, with a minimum of 32 KB/SM
     //   - the L2 cache depends on the actual card, with a minimum of 64 KB/SM

--- a/Eigen/src/Core/products/GeneralBlockPanelKernel.h
+++ b/Eigen/src/Core/products/GeneralBlockPanelKernel.h
@@ -94,10 +94,10 @@ struct CacheSizes {
 EIGEN_DEVICE_FUNC
 inline void manage_caching_sizes(Action action, std::ptrdiff_t* l1, std::ptrdiff_t* l2, std::ptrdiff_t* l3)
 {
-  #ifdef EIGEN_CUDA_ARCH
+  #if defined(EIGEN_CUDA_ARCH) || defined(_OPENMP)
   if (action==GetAction)
   {
-    #if EIGEN_CUDA_ARCH >= 700
+    #if EIGEN_CUDA_ARCH >= 700 || defined(_OPENMP)
     // Volta, Turing, or newer
     //   - the L1 cache is configurable at runtime, with a minimum of 32 KB/SM
     //   - the L2 cache depends on the actual card, with a minimum of 64 KB/SM

--- a/Eigen/src/Core/products/GeneralBlockPanelKernel.h
+++ b/Eigen/src/Core/products/GeneralBlockPanelKernel.h
@@ -94,10 +94,10 @@ struct CacheSizes {
 EIGEN_DEVICE_FUNC
 inline void manage_caching_sizes(Action action, std::ptrdiff_t* l1, std::ptrdiff_t* l2, std::ptrdiff_t* l3)
 {
-  #if defined(EIGEN_CUDA_ARCH) || (defined(__NVCOMPILER) && defined(_OPENMP))
+  #if defined(EIGEN_CUDA_ARCH) || (defined(__NVCOMPILER) && (defined(_OPENMP) || defined(_OPENACC)))
   if (action==GetAction)
   {
-    #if EIGEN_CUDA_ARCH >= 700 || (defined(__NVCOMPILER) && defined(_OPENMP))
+    #if EIGEN_CUDA_ARCH >= 700 || (defined(__NVCOMPILER) && (defined(_OPENMP) || defined(_OPENACC)))
     // Volta, Turing, or newer
     //   - the L1 cache is configurable at runtime, with a minimum of 32 KB/SM
     //   - the L2 cache depends on the actual card, with a minimum of 64 KB/SM


### PR DESCRIPTION
#1 worked with the NVIDIA compilers, but not with GCC.

We don't currently use GCC for GPU offloading, but we do use OpenMP for host threading so it isn't a good idea to break GCC + OpenMP compilation.

This reverts #1 in favour of a simpler approach, where we drop the dynamic cache size setting functionality entirely when compiling with OpenMP. This can be refined later if needed.